### PR TITLE
Support multi-arg Docker Cloud builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Sascha Peilicke <sascha@peilicke.de"
 ARG android_api=28
 ARG android_build_tools=28.0.3
 
-LABEL description="Android SDK ${android_api}"
+LABEL description="Android SDK ${android_api} with build-tools ${android_build_tools}"
 
 ENV ANDROID_SDK_ROOT /opt/android-sdk-linux
 ENV ANDROID_HOME $ANDROID_SDK_ROOT

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+for api_level in ${ANDROID_API[*]} ; do
+    for build_tools in ${ANDROID_BUILD_TOOLS[*]} ; do
+        ./scripts/docker/build \
+            --android-api ${api_level} \
+            --android-build-tools ${build_tools}
+    done
+done

--- a/scripts/docker/build
+++ b/scripts/docker/build
@@ -11,6 +11,7 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 # Default values
 DEFAULT_ANDROID_API=28
+DEFAULT_ANDROID_BUILD_TOOLS=28.0.3
 
 
 # Functions
@@ -18,17 +19,23 @@ function usage {
     echo -e "Usage: ${0} [OPTIONS]"
     echo -e "Options:"
     echo -e "  --android-api API_LEVEL\t(default: ${DEFAULT_ANDROID_API})"
+    echo -e "  --android-build-tools BUILD_TOOLS_VERSION\t(default: ${DEFAULT_ANDROID_BUILD_TOOLS})"
     exit 1
 }
 
 
 # Command-line arguments
 android_api=${DEFAULT_ANDROID_API}
+android_build_tools=${DEFAULT_ANDROID_BUILD_TOOLS}
 while [[ $# -gt 0 ]] ; do
     key="$1"
     case $key in
     --android-api)
         android_api="$2"
+        shift # past argument
+        ;;
+    --android-build-tools)
+        android_build_tools="$2"
         shift # past argument
         ;;
     -h|--help)
@@ -43,13 +50,17 @@ done
 
 
 # Let's roll
+image_tag=${android_api}_${android_build_tools}
+
 safe docker build \
     --build-arg android_api=${android_api} \
-    -t ${DOCKER_IMAGE}:${android_api} \
+    --build-arg android_build_tools=${android_build_tools} \
+    -t ${DOCKER_IMAGE}:${image_tag} \
     .
 
-if [ ${android_api} -ge ${DEFAULT_ANDROID_API} ] ; then
+if [ ${android_api} -eq ${DEFAULT_ANDROID_API} -a \
+     ${android_build_tools} = ${DEFAULT_ANDROID_BUILD_TOOLS} ]; then
     safe docker tag \
-        ${DOCKER_IMAGE}:${android_api} \
+        ${DOCKER_IMAGE}:${image_tag} \
         ${DOCKER_IMAGE}:latest
 fi


### PR DESCRIPTION
By overriding ./hooks/build to use ./scripts/docker/build instead. The
latter has been augmented to allow to customize the Android build-tools
version. The image configuration of saschpe/android-sdk on
cloud.docker.com includes the Bash arrays ANDROID_API and
ANDROID_BUILD_TOOLS that determine which API levels and build-tools
combinations to build.