### PR TITLE
Tag and publish multi-arg Docker Cloud builds

### DIFF
--- a/scripts/docker/build
+++ b/scripts/docker/build
@@ -19,7 +19,8 @@ function usage {
     echo -e "Usage: ${0} [OPTIONS]"
     echo -e "Options:"
     echo -e "  --android-api API_LEVEL\t(default: ${DEFAULT_ANDROID_API})"
-    echo -e "  --android-build-tools BUILD_TOOLS_VERSION\t(default: ${DEFAULT_ANDROID_BUILD_TOOLS})"
+    echo -e "  --android-build-tools VERSION\t(default: ${DEFAULT_ANDROID_BUILD_TOOLS})"
+    echo -e "  --docker-push\t\t\t(optional)"
     exit 1
 }
 
@@ -27,6 +28,7 @@ function usage {
 # Command-line arguments
 android_api=${DEFAULT_ANDROID_API}
 android_build_tools=${DEFAULT_ANDROID_BUILD_TOOLS}
+docker_push=
 while [[ $# -gt 0 ]] ; do
     key="$1"
     case $key in
@@ -37,6 +39,9 @@ while [[ $# -gt 0 ]] ; do
     --android-build-tools)
         android_build_tools="$2"
         shift # past argument
+        ;;
+    --docker-push)
+        docker_push=true
         ;;
     -h|--help)
         usage
@@ -55,12 +60,16 @@ image_tag=${android_api}_${android_build_tools}
 safe docker build \
     --build-arg android_api=${android_api} \
     --build-arg android_build_tools=${android_build_tools} \
-    -t ${DOCKER_IMAGE}:${image_tag} \
-    .
+    --tag ${DOCKER_IMAGE}:${image_tag} .
+if [ ${docker_push} ] ; then
+    safe docker push ${DOCKER_IMAGE}:${image_tag}
+fi
 
+# Update 'latest' tag if script argument match defaults
 if [ ${android_api} -eq ${DEFAULT_ANDROID_API} -a \
      ${android_build_tools} = ${DEFAULT_ANDROID_BUILD_TOOLS} ]; then
-    safe docker tag \
-        ${DOCKER_IMAGE}:${image_tag} \
-        ${DOCKER_IMAGE}:latest
+    safe docker tag ${DOCKER_IMAGE}:${image_tag} ${DOCKER_IMAGE}:latest
+    if [ ${docker_push} ] ; then
+        safe docker push ${DOCKER_IMAGE}:latest
+    fi
 fi


### PR DESCRIPTION
Add '--docker-push' option to ./scripts/docker/build to optionally push
the resulting image. This is used by ./hooks/build for Docker Cloud
auto-builds [0,1].

[0] https://docs.docker.com/docker-hub/builds/
[1] https://docs.docker.com/docker-hub/builds/advanced/