### PR TITLE
Rebase image on JDK-11 and latest command-line tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,56 @@
-FROM openjdk:8-alpine3.9
-LABEL maintainer="Sascha Peilicke <sascha@peilicke.de"
+# 
+# Android SDK container image with build-tools.
+#
+# Contains JDK, Android SDK and Android Build Tools. Each version is
+# configurable. Build and publish with default arguments:
+#
+#   $ ./scripts/docker/build --docker-push
+#
+# Build with custom arguments:
+#
+#   $ ./scripts/docker/build --android-api 30
+#
 
-ARG android_api=29
-ARG android_build_tools=29.0.2
+ARG jdk=11
 
-LABEL description="Android SDK ${android_api} with build-tools ${android_build_tools}"
+# Stage 1, build container
+FROM openjdk:8-alpine3.9 AS Build
 
 ENV ANDROID_SDK_ROOT /opt/android-sdk-linux
-ENV ANDROID_HOME $ANDROID_SDK_ROOT
-ENV GLIBC 2.25-r0
-ENV PATH $PATH:$ANDROID_SDK_ROOT/tools/bin
 
-RUN apk add --no-cache --virtual=.build-dependencies \
-        bash \
-        file \
-        git \
-        git-lfs \
-        openssl \
-        wget \
-        unzip \
-    && wget --quiet https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -O /etc/apk/keys/sgerrand.rsa.pub \
-    && wget --quiet https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC}/glibc-${GLIBC}.apk -O /tmp/glibc.apk \
-    && wget --quiet https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC}/glibc-bin-${GLIBC}.apk -O /tmp/glibc-bin.apk \
-    && apk add --no-cache /tmp/glibc.apk /tmp/glibc-bin.apk \
-    && rm -rf /tmp/* /var/cache/apk/* \
-    && openssl version
+RUN apk add --no-cache wget unzip; \
+    rm -rf /var/cache/apk/*
 RUN wget --quiet https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -O /tmp/tools.zip \
-    && mkdir -p $ANDROID_SDK_ROOT \
-    && unzip -q /tmp/tools.zip -d $ANDROID_SDK_ROOT \
-    && rm -v /tmp/tools.zip \
-    && mkdir -p /root/.android/ \
-    && touch /root/.android/repositories.cfg
-RUN yes | sdkmanager \
+    mkdir -p ${ANDROID_SDK_ROOT}; \
+    unzip -q /tmp/tools.zip -d ${ANDROID_SDK_ROOT}; \
+    rm -v /tmp/tools.zip; \
+    mkdir -p /root/.android/; \
+    touch /root/.android/repositories.cfg; \
+    yes | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager "cmdline-tools;latest" >/dev/null
+
+
+# Stage 2, distribution container
+
+FROM openjdk:${jdk}-slim
+ARG android_api=29
+ARG android_build_tools=30.0.1
+LABEL maintainer="Sascha Peilicke <sascha@peilicke.de"
+LABEL description="Android SDK ${android_api} with build-tools ${android_build_tools} using JDK ${jdk}"
+
+ENV ANDROID_SDK_ROOT /opt/android-sdk-linux
+ENV PATH $PATH:${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin
+
+RUN apt-get update; \
+	apt-get install -y --no-install-recommends \
+		git \
+		git-lfs \
+		openssl \
+	; \
+	rm -rf /var/lib/apt/lists/*
+COPY --from=BUILD ${ANDROID_SDK_ROOT} ${ANDROID_SDK_ROOT}
+RUN yes | sdkmanager --licenses >/dev/null; \
+    sdkmanager \
         "build-tools;${android_build_tools}" \
-        "platforms;android-${android_api}" >/dev/null \
-    && rm -rf  \
-        # Delete proguard docs and examples
-        $ANDROID_SDK_ROOT/tools/proguard/examples \
-        $ANDROID_SDK_ROOT/tools/proguard/docs \
-    && sdkmanager --list | sed -e '/Available Packages/q'
+        "platforms;android-${android_api}"; \
+    sdkmanager --list | sed -e '/^$/q'; \
+    java -version

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/saschpe/android-sdk.svg)](https://hub.docker.com/r/saschpe/android-sdk/)
 [![Docker Build Status](https://img.shields.io/docker/build/saschpe/android-sdk.svg)](https://hub.docker.com/r/saschpe/android-sdk/)
 
-Android SKD Docker container based on Alpine Linux.
+Android SDK OCI container image with pre-installed build-tools based on latest
+command-line tools and JDK 11 (or later).
 
 
 ## Usage

--- a/hooks/build
+++ b/hooks/build
@@ -1,10 +1,13 @@
 #!/bin/bash
+#
+# Docker Hub Automated Builds hook
+#
 
 for api_level in ${ANDROID_API[*]} ; do
-    for build_tools in ${ANDROID_BUILD_TOOLS[*]} ; do
-        ./scripts/docker/build \
-            --android-api ${api_level} \
-            --android-build-tools ${build_tools} \
-            --docker-push
-    done
+  for build_tools in ${ANDROID_BUILD_TOOLS[*]} ; do
+    ./scripts/docker/build \
+      --android-api ${api_level} \
+      --android-build-tools ${build_tools} \
+      --docker-push
+  done
 done

--- a/scripts/docker/build
+++ b/scripts/docker/build
@@ -1,8 +1,7 @@
 #!/bin/bash
 #
-# Script to build transpiler Docker image.
-#
-# Needs root privileges or 'docker' group membership
+# Script to build container image. Needs root privileges or 'docker' group
+# membership when using Docker. Prefer using Podman on Linux instead.
 
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${SCRIPT_DIR}/../inc.constants"
@@ -12,66 +11,73 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # Default values
 DEFAULT_ANDROID_API=$(grep android_api= "${SCRIPT_DIR}/../../Dockerfile" | cut -d"=" -f2)
 DEFAULT_ANDROID_BUILD_TOOLS=$(grep android_build_tools= "${SCRIPT_DIR}/../../Dockerfile" | cut -d"=" -f2)
+DEFAULT_JDK=$(grep jdk= "${SCRIPT_DIR}/../../Dockerfile" | cut -d"=" -f2)
 
 
 # Functions
 function usage {
-    echo -e "Usage: ${0} [OPTIONS]"
-    echo -e "Options:"
-    echo -e "  --android-api API_LEVEL\t(default: ${DEFAULT_ANDROID_API})"
-    echo -e "  --android-build-tools VERSION\t(default: ${DEFAULT_ANDROID_BUILD_TOOLS})"
-    echo -e "  --docker-push\t\t\t(optional)"
-    exit 1
+  echo -e "Usage: ${0} [OPTIONS]"
+  echo -e "Options:"
+  echo -e "  --android-api API_LEVEL\t(default: ${DEFAULT_ANDROID_API})"
+  echo -e "  --android-build-tools VERSION\t(default: ${DEFAULT_ANDROID_BUILD_TOOLS})"
+  echo -e "  --jdk VERSION\t\t\t(default: ${DEFAULT_JDK})"
+  echo -e "  --docker-push\t\t\t(optional)"
+  exit 1
 }
 
 
 # Command-line arguments
-android_api=${DEFAULT_ANDROID_API}
-android_build_tools=${DEFAULT_ANDROID_BUILD_TOOLS}
+android_api="${DEFAULT_ANDROID_API}"
+android_build_tools="${DEFAULT_ANDROID_BUILD_TOOLS}"
+jdk="${DEFAULT_JDK}"
 docker_push=
 while [[ $# -gt 0 ]] ; do
-    key="$1"
-    case $key in
-    --android-api)
-        android_api="$2"
-        shift # past argument
-        ;;
-    --android-build-tools)
-        android_build_tools="$2"
-        shift # past argument
-        ;;
-    --docker-push)
-        docker_push=true
-        ;;
-    -h|--help)
-        usage
-        shift # past argument
-        ;;
-    *) # unknown option
-        ;;
-    esac
-    shift # past argument or value
+  key="$1"
+  case $key in
+  --android-api)
+    android_api="$2"
+    shift # past argument
+    ;;
+  --android-build-tools)
+    android_build_tools="$2"
+    shift # past argument
+    ;;
+  --jdk)
+    jdk="$2"
+    shift # past argument
+    ;;
+  --docker-push)
+    docker_push=true
+    ;;
+  -h|--help)
+    usage
+    shift # past argument
+    ;;
+  *) # unknown option
+    ;;
+  esac
+  shift # past argument or value
 done
 
 
 # Let's roll
-image_tag=${android_api}_${android_build_tools}
+image_tag=jdk${jdk}_api${android_api}_${android_build_tools}
 
-echo "Building image tag ${image_tag}..."
+approve "Building image tag ${image_tag}..."
 safe docker build \
-    --build-arg android_api=${android_api} \
-    --build-arg android_build_tools=${android_build_tools} \
-    --tag ${DOCKER_IMAGE}:${image_tag} .
+  --build-arg android_api=${android_api} \
+  --build-arg android_build_tools=${android_build_tools} \
+  --tag ${DOCKER_IMAGE}:${image_tag} .
 if [ ${docker_push} ] ; then
-    safe docker push ${DOCKER_IMAGE}:${image_tag}
+  safe docker push ${DOCKER_IMAGE}:${image_tag}
 fi
 
 # Update 'latest' tag if script argument match defaults
 if [ ${android_api} -eq ${DEFAULT_ANDROID_API} -a \
      ${android_build_tools} = ${DEFAULT_ANDROID_BUILD_TOOLS} ]; then
-    echo "Tagging as 'latest'..."
-    safe docker tag ${DOCKER_IMAGE}:${image_tag} ${DOCKER_IMAGE}:latest
-    if [ ${docker_push} ] ; then
-        safe docker push ${DOCKER_IMAGE}:latest
-    fi
+  approve "Tagging as 'latest'..."
+  safe docker tag ${DOCKER_IMAGE}:${image_tag} ${DOCKER_IMAGE}:latest
+  if [ ${docker_push} ] ; then
+    safe docker push ${DOCKER_IMAGE}:latest
+  fi
 fi

--- a/scripts/docker/run
+++ b/scripts/docker/run
@@ -13,5 +13,5 @@ docker pull ${DOCKER_IMAGE}:latest
 
 # Run container
 safe docker run \
-    --rm \
-    ${DOCKER_IMAGE}:latest
+  --rm \
+  ${DOCKER_IMAGE}:latest

--- a/scripts/inc.functions
+++ b/scripts/inc.functions
@@ -3,16 +3,29 @@
 # Collection of shared functions
 #
 
-function die {
-    echo -e "$@"
-    exit 1
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+function approve() {
+  echo -e "${GREEN}$*${NC}"
 }
 
-function safe {
-    "$@"
-    local status=$?
-    if [ $status -ne 0 ]; then
-        die "\nBUILD FAILED\nAfter invoking \"$@\"\n" >&2
-    fi
-    return $status
+function warn() {
+  echo -e "${YELLOW}$*${NC}"
+}
+
+function die() {
+  echo -e "${RED}$*${NC}"
+  exit 1
+}
+
+function safe() {
+  "$@"
+  local status=$?
+  if [[ ${status} -ne 0 ]]; then
+    die "\nBUILD FAILED\nAfter invoking \"$*\"\n" >&2
+  fi
+  return ${status}
 }


### PR DESCRIPTION
Refresh shell scripting, increase comments and use two-phase image
build. The first phase is necessary because the Android SDK
"commandlinetools-linux" download still includes the outdated
'sdkmanager' binary that only works with Java 1.8.