### PR TITLE
Add JDK support to scripting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# 
+#
 # Android SDK container image with build-tools.
 #
 # Contains JDK, Android SDK and Android Build Tools. Each version is
@@ -28,8 +28,8 @@ RUN wget --quiet https://dl.google.com/android/repository/sdk-tools-linux-433379
 
 # Stage 2, distribution container
 FROM openjdk:${jdk}-slim
-ARG android_api=29
-ARG android_build_tools=30.0.1
+ARG android_api=30
+ARG android_build_tools=30.0.3
 LABEL maintainer="Sascha Peilicke <sascha@peilicke.de"
 LABEL description="Android SDK ${android_api} with build-tools ${android_build_tools} using JDK ${jdk}"
 ENV ANDROID_SDK_ROOT /opt/android-sdk-linux

--- a/hooks/build
+++ b/hooks/build
@@ -5,9 +5,12 @@
 
 for api_level in ${ANDROID_API[*]} ; do
   for build_tools in ${ANDROID_BUILD_TOOLS[*]} ; do
-    ./scripts/docker/build \
-      --android-api ${api_level} \
-      --android-build-tools ${build_tools} \
-      --docker-push
+    for jdk in ${JDK[*]} ; do
+      ./scripts/docker/build \
+        --android-api ${api_level} \
+        --android-build-tools ${build_tools} \
+        --jdk ${jdk} \
+        --docker-push
+    done
   done
 done

--- a/scripts/docker/build
+++ b/scripts/docker/build
@@ -67,6 +67,7 @@ approve "Building image tag ${image_tag}..."
 safe docker build \
   --build-arg android_api=${android_api} \
   --build-arg android_build_tools=${android_build_tools} \
+  --build-arg jdk=${jdk} \
   --tag ${DOCKER_IMAGE}:${image_tag} .
 if [ ${docker_push} ] ; then
   safe docker push ${DOCKER_IMAGE}:${image_tag}
@@ -74,7 +75,8 @@ fi
 
 # Update 'latest' tag if script argument match defaults
 if [ ${android_api} -eq ${DEFAULT_ANDROID_API} -a \
-     ${android_build_tools} = ${DEFAULT_ANDROID_BUILD_TOOLS} ]; then
+     ${android_build_tools} = ${DEFAULT_ANDROID_BUILD_TOOLS} -a \
+     ${jdk} -eq ${DEFAULT_JDK} ]; then
   approve "Tagging as 'latest'..."
   safe docker tag ${DOCKER_IMAGE}:${image_tag} ${DOCKER_IMAGE}:latest
   if [ ${docker_push} ] ; then


### PR DESCRIPTION
Allow building variants for multiple JDKs, e.g. 11 and 16 currently.