### PR TITLE
Update JDKs to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        jdk: [ 11.0.19_7, 17.0.7_7 ]
+        jdk: [ 11.0.20_8, 17.0.8_7 ]
         android: [ 31, 32, 33, 34 ]
     steps:
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@
 #
 # Build with custom arguments:
 #
-#   $ ./scripts/build --android 33 --jdk 17.0.7_7
+#   $ ./scripts/build --android 33 --jdk 17.0.8_7
 #
 
-ARG jdk=17.0.7_7
+ARG jdk=17.0.8_7
 
 FROM eclipse-temurin:${jdk}-jdk
 ARG android=33

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@
 [![Docker Image Size (latest by date)](https://img.shields.io/docker/image-size/saschpe/android-sdk)](https://hub.docker.com/r/saschpe/android-sdk)
 
 Android SDK OCI container image with pre-installed build-tools based on the latest
-command-line tools and JDK 11 (or later).
+command-line tools and JDK 11 or later.
 
 ## Android SDK and JDK support
 
 The following JDK and Android SDK API level combinations are currently supported:
 
-|    | 11.0.19_7 | 17.0.7_7 |
-|----|-----------|----------|
-| 31 | ✅         | ✅        |
-| 32 | ✅         | ✅        |
-| 33 | ✅         | ✅        |
-| 34 | ✅         | ✅        |
+|    | 11.0 | 17.0 |
+|----|------|------|
+| 31 | ✅   | ✅   |
+| 32 | ✅   | ✅   |
+| 33 | ✅   | ✅   |
+| 34 | ✅   | ✅   |
 
 ## Usage
 


### PR DESCRIPTION
Old tags continue to stay around, add recent JDK releases for automated
builds.
