### PR TITLE
Set read-only permissions and enable Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: ".github/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   IMAGE: saschpe/android-sdk
   PLATFORMS: linux/amd64,linux/arm64
@@ -30,7 +33,7 @@ jobs:
         android: [ 34, 35 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
### Summary

This pull request includes the following updates:

- **Set read-only permissions for GitHub Actions workflows**: Updated `main.yml` to include `contents: read` in the permissions block, aligning with the principle of least privilege.
- **Add Dependabot configuration**: Configured Dependabot to automate dependency updates for Gradle, GitHub Actions, and Docker. Updates are scheduled weekly to maintain security and current versions. 

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have adhered to all relevant guidelines while making this