### PR TITLE
Update JDK versions in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        jdk: [ 17.0.13_11, 21.0.5_11, 22.0.2_9 ]
+        jdk: [ 17.0.14_7, 21.0.6_7, 22.0.2_9 ]
         android: [ 34, 35 ]
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description

This pull request updates the JDK versions in the GitHub Actions workflow matrix to the latest patch versions:

- **17.0.14_7**
- **21.0.6_7**

These updates aim to improve the workflow's stability and compatibility by ensuring the CI pipeline relies on up-to-date dependencies.